### PR TITLE
feat(api): introduce test api in app

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VUE_APP_API_URL=http://106.54.69.78:8080/api

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,5 +15,7 @@ module.exports = {
   rules: {
     'no-console': 1,
     'no-debugger': 1,
+    'implicit-arrow-linebreak': 0,
+    'import/prefer-default-export': 0,
   },
 };

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,0 +1,1 @@
+export { default as testClient } from './test';

--- a/src/apis/test.ts
+++ b/src/apis/test.ts
@@ -1,0 +1,39 @@
+import log from '@/utils/logger';
+// import { API_URL } from '@/utils/config';
+import axios from 'axios';
+
+/** 请求参数 */
+interface TestReq {
+  /** 用户 ID */
+  uid: string;
+}
+
+/** 返回列表项 */
+interface TestRespItem {
+  /** 用户 ID */
+  uid: string;
+  /** BV 号 */
+  bv: string;
+}
+
+/** 返回 */
+type TestResp = TestRespItem[];
+
+/** 接口函数 */
+const test: (req: TestReq) => Promise<TestResp> = ({ uid }) =>
+  new Promise<TestResp>((resolve, reject) => {
+    log.info('testClient.test');
+    // FIXME: 后端上跨域后应该用 .get(`${API_URL}/records/xxx`)
+    axios
+      .get(`/api/records/byUid/${uid}`)
+      .then((resp) => {
+        resolve(resp.data);
+      })
+      .catch((err) => reject(err));
+  });
+
+const testClient = {
+  test,
+};
+
+export default testClient;

--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -8,12 +8,20 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+import { testClient } from '@/apis';
+import logger from '@/utils/logger';
 import HelloWorld from './components/HelloWorld.vue';
 
 export default defineComponent({
   name: 'App',
   components: {
     HelloWorld,
+  },
+  mounted() {
+    // FIXME: 测试用，过后删去
+    testClient.test({ uid: 'bili_5249176387' }).then((data) => {
+      logger.log(data);
+    });
   },
 });
 </script>

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,0 +1,1 @@
+export const API_URL = process.env.VUE_APP_API_URL;

--- a/vue.config.js
+++ b/vue.config.js
@@ -25,4 +25,16 @@ module.exports = {
     popup: 'src/popup/main.ts',
     background: 'src/background/main.ts',
   },
+  // FIXME: 后端上跨域后删掉这个
+  devServer: {
+    proxy: {
+      '/api': {
+        target: 'http://106.54.69.78:8080/api', // API 服务器的地址
+        changeOrigin: true,
+        pathRewrite: {
+          '^/api': '',
+        },
+      },
+    },
+  },
 };


### PR DESCRIPTION
写了一个在 Vue App 接入后端 API 的测试例子

### 如何测试

默认在主组件 mount 时发出测试请求，打开控制台可看到返回的数据体。

### 待解决的问题

当前跨域暂时用 Vue CLI proxyTable 解决，在后端完成跨域配置后前端应当去除这部分工作造成的影响