### PR TITLE
build(webpack): 独立各模块打包时的模块依赖

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -17,7 +17,7 @@
   "content_scripts": [
     {
       "matches": ["*://*.bilibili.com/*"],
-      "js": ["js/chunk-vendors.js", "js/popup.js"],
+      "js": ["js/popup.js"],
       "css": ["css/popup.css"]
     }
   ],

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,18 +1,12 @@
-module.exports = {
-  // chainWebpack: (config) => {
-  // config.optimization.minimize(false);
-  // config.entryPoints.delete('app');
+const DEBUG_MODE = process.env.VUE_APP_DEBUG;
 
-  // config.entry('app')
-  //   .add('./src/app/main.ts')
-  //   .end();
-  //   .entry('popup')
-  //   .add('./src/popup/main.ts')
-  //   .end()
-  //   .entry('background')
-  //   .add('./src/background/main.ts')
-  //   .end();
-  // },
+module.exports = {
+  chainWebpack: (config) => {
+    config.optimization.splitChunks(false);
+  },
+  configureWebpack: {
+    devtool: DEBUG_MODE ? 'inline-source-map' : 'source-map',
+  },
   css: {
     loaderOptions: {
       less: {
@@ -29,9 +23,15 @@ module.exports = {
       template: 'public/index.html',
       filename: 'index.html',
       title: '洄游',
-      chunks: ['chunk-vendors', 'chunk-common', 'app'],
+      chunks: ['app'],
     },
-    popup: 'src/popup/main.ts',
-    background: 'src/background/main.ts',
+    popup: {
+      entry: 'src/popup/main.ts',
+      chunks: ['popup'],
+    },
+    background: {
+      entry: 'src/background/main.ts',
+      chunks: ['background'],
+    },
   },
 };


### PR DESCRIPTION
此前三个模块打包时会将第三方包都打包进 `chunk-vendors` 中，这是不必要的，会导致将类似 vue 等在其他模块没有用到的包也打进去。

现在每个模块打包将独立进行 tree shaking。

此前的打包大小：

```sh
  File                        Size                                        Gzipped

  dist\js\chunk-vendors.js    153.55 KiB                                  55.30 KiB
  dist\js\popup.js            12.15 KiB                                   4.30 KiB
  dist\js\background.js       10.23 KiB                                   3.40 KiB
  dist\js\app.js              9.06 KiB                                    3.38 KiB
  dist\css\app.css            1.97 KiB                                    0.74 KiB
  dist\css\popup.css          0.75 KiB                                    0.34 KiB
```

现在的打包大小：

```sh
  File                     Size                                         Gzipped

  dist\js\app.js           118.12 KiB                                   43.05 KiB
  dist\js\popup.js         94.73 KiB                                    32.58 KiB
  dist\js\background.js    78.16 KiB                                    27.06 KiB
  dist\css\app.css         1.97 KiB                                     0.74 KiB
  dist\css\popup.css       0.75 KiB                                     0.34 KiB
```